### PR TITLE
Pass account_id to bptimer for multi-region support (needed by 12/18/25 for SEA/JPKR)

### DIFF
--- a/algo/packet.js
+++ b/algo/packet.js
@@ -1012,6 +1012,10 @@ class PacketProcessor {
                 this.userDataManager.setName(playerUid, charBase.Name);
             }
 
+            if (charBase.AccountId) {
+                this.userDataManager.setAttrKV(playerUid, 'account_id', charBase.AccountId);
+            }
+
             if (charBase.FightPoint) this.userDataManager.setFightPoint(playerUid, charBase.FightPoint);
 
             if (!vData.ProfessionList) return;
@@ -1308,6 +1312,9 @@ class PacketProcessor {
             return;
         }
 
+    // Get account_id for the local player (used for region detection)
+    const account_id = this.userDataManager.getUser(localPlayerInfo.playerId)?.attr?.account_id;
+
     // Preferir el template id (AttrId) almacenado en enemyCache.id. Si no existe, no enviar
     const templateId = this.userDataManager.enemyCache.id ? this.userDataManager.enemyCache.id.get(monsterUuid) : null;
     const monsterId = templateId != null ? templateId : null; // for BPTimer we require template id
@@ -1386,6 +1393,14 @@ class PacketProcessor {
                     this.logger.warn(`[BPTimer] Position dropped as invalid or out of bounds: ${JSON.stringify(position)}`);
                 }
                 this.logger.info('[BPTimer] Enviando reporte sin posición (pos inválida, ausente o no requerida para este mob)');
+            }
+
+            if (account_id) {
+                payload.account_id = account_id;
+            }
+
+            if (localPlayerInfo.playerId) {
+                payload.uid = localPlayerInfo.playerId;
             }
 
             if (!this.bptimerClient) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpsr-meter",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "BPSR Meter",
   "main": "electron-main.js",
   "bin": {
@@ -24,7 +24,7 @@
   "license": "AGPL-3.0",
   "packageManager": "pnpm@10.13.1",
   "dependencies": {
-    "@woheedev/bptimer-api-client": "^0.1.4",
+    "@woheedev/bptimer-api-client": "^0.2.0",
     "cap": "^0.2.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
Changes:

feat: add account_id handling and pass along with uid to bptimer
chore: update bptimer-api-client to 0.2.0
chore: patch version for release