### PR TITLE
chore: update bptimer-api-client to v0.2.2 and bump version to 2.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpsr-meter",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "BPSR Meter",
   "main": "electron-main.js",
   "bin": {
@@ -24,7 +24,7 @@
   "license": "AGPL-3.0",
   "packageManager": "pnpm@10.13.1",
   "dependencies": {
-    "@woheedev/bptimer-api-client": "^0.2.0",
+    "@woheedev/bptimer-api-client": "^0.2.2",
     "cap": "^0.2.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
# Changes
- Added mob record prefetch to replace hardcoded values

This change will ensure that there is no need to push a new api client update when a new mob is added/removed.

**Note:** This is a low priority update and currently only used to capture HP reports for the new `Snow Nappo` event mob.